### PR TITLE
Replace deprecated panelUrl() method

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,9 +6,9 @@ Kirby::plugin('medienbaecker/redirect', [
       'computed' => [
         'redirect' => function () {
           if($this->model()->parent()) {
-            return $this->model()->parent()->panelUrl();	
+            return $this->model()->parent()->panel()->url();	
           }
-          return $this->model()->site()->panelUrl();	
+          return $this->model()->site()->panel()->url();	
         }
       ]
     ]


### PR DESCRIPTION
panelUrl() is deprecated as of Kirby v3.7 which broke the plugin. This fix makes it work again.